### PR TITLE
Stop github action cron

### DIFF
--- a/.github/workflows/update-as-nightly.yml
+++ b/.github/workflows/update-as-nightly.yml
@@ -2,9 +2,10 @@ name: Create a PR for release with the newest A-S version available
 
 # Controls when the workflow will run
 on:
-  schedule:
+  # Ecosia: Stop action from running
+  # schedule:
   # Runs 8:00am UTC each day
-  - cron: '0 8 * * *'
+  # - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Since we [merged the latest changes](https://github.com/ecosia/rust-components-swift/pull/1), there was Github action with a cron schedule trying to run every day.

This is not relevant for us at Ecosia and comes from the fork, therefore stopping it to avoid unnecessary costs.